### PR TITLE
SC5 Styleguides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ yarn.lock
 
 # front-end
 *.css.map
+assets/styleguide/*

--- a/assets/src/css/base/_index.scss
+++ b/assets/src/css/base/_index.scss
@@ -1,0 +1,9 @@
+// ----------------------------------------
+//
+// Resets and defaults.
+// Global namespace.
+//
+// ----------------------------------------
+
+@import 'global';
+@import 'wp-core';

--- a/assets/src/css/helpers/_colors.scss
+++ b/assets/src/css/helpers/_colors.scss
@@ -1,0 +1,15 @@
+// Site Colors
+//
+// Colors used throughout the site
+//
+// $g-color-black - black
+// $g-color-white - white
+//
+// markup:
+// <div proto-ignore style="background-color:{$modifiers};height:50px;"><span style="font-family:monospace;padding:10px;background-color:#fff;">{$modifiers}</span></div>
+//
+// Styleguide 0.1
+
+$g-color-black: black;
+$g-color-white: white;
+$g-color-red: #f00;

--- a/assets/src/css/helpers/_index.scss
+++ b/assets/src/css/helpers/_index.scss
@@ -1,11 +1,12 @@
-// ----------------------------------------
+// Helpers
 //
-// FM Radio helpers and variables.
-// No CSS outputted.
+// This contains core SCSS variables and mixins that can be loaded into section
+// CSS files. It contains no outputting SCSS.
 //
-// ----------------------------------------
+// Styleguide 0.0
 
 @import 'variables';
+@import 'colors'; // 0.1
 @import 'typography';
 @import 'scss-query/query';
 @import 'mixins';

--- a/assets/src/css/helpers/_index.scss
+++ b/assets/src/css/helpers/_index.scss
@@ -7,6 +7,6 @@
 
 @import 'variables';
 @import 'colors'; // 0.1
-@import 'typography';
+@import 'typography'; // 0.2
 @import 'scss-query/query';
 @import 'mixins';

--- a/assets/src/css/helpers/_typography.scss
+++ b/assets/src/css/helpers/_typography.scss
@@ -1,6 +1,20 @@
 // Typography
 //
-// Font stacks and typography styles used site-wide
+// Font families and typography styles used site-wide
+//
+// $g-font-family-sans - Lato, Tahoma, Verdana, Segoe, sans-serif
+// $g-font-family-serif - 'Source Serif Pro', Georgia, Times, 'Times New Roman', serif
+//
+// markup:
+// <h1 style="font-family: {$modifiers}">The quick brown fox jumps over the lazy dog.</h1>
+// <h2 style="font-family: {$modifiers}">The quick brown fox jumps over the lazy dog.</h2>
+// <h3 style="font-family: {$modifiers}">The quick brown fox jumps over the lazy dog.</h3>
+// <h4 style="font-family: {$modifiers}">The quick brown fox jumps over the lazy dog.</h4>
+// <h5 style="font-family: {$modifiers}">The quick brown fox jumps over the lazy dog.</h5>
+// <h6 style="font-family: {$modifiers}">The quick brown fox jumps over the lazy dog.</h6>
+// <p style="font-family: {$modifiers}">The quick brown fox jumps over the lazy dog.</p>
+//
+// Styleguide 0.2
 
 //
 // Font weights
@@ -14,8 +28,10 @@ $bold: 700;
 // Fallback generated with: https://shtrihstr.github.io/font-fallback/
 //
 
+$g-font-family-sans: Lato, Tahoma, Verdana, Segoe, sans-serif;
+
 %g-font-family-sans {
-	font-family: Lato, Tahoma, Verdana, Segoe, sans-serif;
+	font-family: $g-font-family-sans;
 
 	.fonts-loading & {
 		font-family: Tahoma, Verdana, Segoe, sans-serif;
@@ -26,6 +42,8 @@ $bold: 700;
 		word-spacing: -0.143183em;
 	}
 }
+
+$g-font-family-serif: 'Source Serif Pro', Georgia, Times, 'Times New Roman', serif;
 
 %g-font-family-serif {
 	font-family: 'Source Serif Pro', Georgia, Times, 'Times New Roman', serif;

--- a/assets/src/css/main.scss
+++ b/assets/src/css/main.scss
@@ -8,14 +8,10 @@
 @import 'helpers/index';
 
 // Resets and defaults. Styleguide 1.x
-// @import 'base/index';
+@import 'base/index';
 
-// Components
-//
-// Styleguide 2.x
-// @import 'components/c-logo';
+// Components. Styleguide 2.x
+@import 'components/c-logo';
 
-// Layouts
-//
-// Styleguide 3.x
-// @import 'layouts/l-header';
+// Layouts. Styleguide 3.x
+@import 'layouts/l-header';

--- a/assets/src/css/main.scss
+++ b/assets/src/css/main.scss
@@ -4,19 +4,18 @@
 //
 // ----------------------------------------
 
-// Helpers
-
+// Helpers and variables. Styleguides 0.x
 @import 'helpers/index';
 
-// Base
-
-@import 'base/global';
-@import 'base/wp-core';
+// Resets and defaults. Styleguide 1.x
+// @import 'base/index';
 
 // Components
-
-@import 'components/c-logo';
+//
+// Styleguide 2.x
+// @import 'components/c-logo';
 
 // Layouts
-
-@import 'layouts/l-header';
+//
+// Styleguide 3.x
+// @import 'layouts/l-header';

--- a/assets/src/css/styleguide.md
+++ b/assets/src/css/styleguide.md
@@ -1,0 +1,3 @@
+# Styleguide
+
+To generate the styleguide: `npm run styleguide`.

--- a/assets/tasks/icons.js
+++ b/assets/tasks/icons.js
@@ -74,16 +74,12 @@ const iconConfig = {
 	markupFile: faviconDataFile
 };
 
-const generateIcons = function(done) {
-	realFavicon.generateFavicon( iconConfig, function() {
-		done();
-	} );
-};
+gulp.task( 'generateIcons', function() {
+	realFavicon.generateFavicon( iconConfig );
+} );
 
-const delRedundantManifest = function(done) {
-	del( [ iconDest + 'manifest.json', iconDest + 'faviconData.json' ]).then( function() {
-		done();
-	} );
-};
+gulp.task( 'delRedundantManifest', function() {
+	del( [ iconDest + 'manifest.json', iconDest + 'faviconData.json' ]);
+} );
 
-module.exports = gulp.series( generateIcons, delRedundantManifest );
+gulp.task('default', [ 'generateIcons', 'delRedundantManifest' ]);

--- a/assets/tasks/styleguide.js
+++ b/assets/tasks/styleguide.js
@@ -1,42 +1,34 @@
 const gulp = require('gulp');
 const styleguide = require('sc5-styleguide/lib/modules/cli/styleguide-cli');
 
+// Paths definitions
+const styleguideTitle = 'Styleguide';
+const readmePath = 'assets/src/css/styleguide.md';
+const kssSourcePath = 'assets/src/css/**/*.scss';
+const styleSourcePath = 'assets/dist/css/*.css';
+
+var outputPath = 'assets/styleguide';
+// Absolute path when hosted
+var appRootPath = '/assets/styleguide';
+
 gulp.task( 'buildStyleguide', function() {
 	let is_development_mode = true;
 	if ( 'production' === process.env.NODE_ENV ) {
 		is_development_mode = false;
 	}
-	styleguide({
-
-		// Styleguide title
-		title: 'Styleguide',
-
-		// Styleguide overview path
-		overviewPath: 'assets/src/css/styleguide.md',
-
-		// KSS source material
-		kssSource: 'assets/src/css/**/*.scss',
-
-		// Stylesheets to include
+	styleguide( {
+		title: styleguideTitle,
+		overviewPath: readmePath,
+		kssSource: kssSourcePath,
 		styleSource: [
-			'assets/dist/css/main.css'
+			styleSourcePath
 		],
-
-		rootPath: '/assets/styleguide',
-
-		appRoot: '/assets/styleguide',
-
-		// Output path
-		output: 'assets/styleguide',
-
-		// Watch for changes
+		rootPath: outputPath,
+		output: outputPath,
+		appRoot: appRootPath,
 		watch: is_development_mode,
-
-		// Serve
 		server: false
-
-	});
-
+	} );
 });
 
 gulp.task('default', [ 'buildStyleguide' ]);

--- a/assets/tasks/styleguide.js
+++ b/assets/tasks/styleguide.js
@@ -2,9 +2,9 @@ const gulp = require('gulp');
 const styleguide = require('sc5-styleguide/lib/modules/cli/styleguide-cli');
 
 gulp.task( 'buildStyleguide', function() {
-	let development_mode_active = true;
+	let is_development_mode = true;
 	if ( 'production' === process.env.NODE_ENV ) {
-		development_mode_active = false;
+		is_development_mode = false;
 	}
 	styleguide({
 
@@ -18,8 +18,6 @@ gulp.task( 'buildStyleguide', function() {
 		kssSource: 'assets/src/css/**/*.scss',
 
 		// Stylesheets to include
-		// global.css: primary site styles
-		// styleguide.css: styleguide-only styles
 		styleSource: [
 			'assets/dist/css/main.css'
 		],
@@ -32,7 +30,7 @@ gulp.task( 'buildStyleguide', function() {
 		output: 'assets/styleguide',
 
 		// Watch for changes
-		watch: development_mode_active,
+		watch: is_development_mode,
 
 		// Serve
 		server: false

--- a/assets/tasks/styleguide.js
+++ b/assets/tasks/styleguide.js
@@ -1,0 +1,44 @@
+const gulp = require('gulp');
+const styleguide = require('sc5-styleguide/lib/modules/cli/styleguide-cli');
+
+gulp.task( 'buildStyleguide', function() {
+	let development_mode_active = true;
+	if ( 'production' === process.env.NODE_ENV ) {
+		development_mode_active = false;
+	}
+	styleguide({
+
+		// Styleguide title
+		title: 'Styleguide',
+
+		// Styleguide overview path
+		overviewPath: 'assets/src/css/styleguide.md',
+
+		// KSS source material
+		kssSource: 'assets/src/css/**/*.scss',
+
+		// Stylesheets to include
+		// global.css: primary site styles
+		// styleguide.css: styleguide-only styles
+		styleSource: [
+			'assets/dist/css/main.css'
+		],
+
+		rootPath: '/assets/styleguide',
+
+		appRoot: '/assets/styleguide',
+
+		// Output path
+		output: 'assets/styleguide',
+
+		// Watch for changes
+		watch: development_mode_active,
+
+		// Serve
+		server: false
+
+	});
+
+});
+
+gulp.task('default', [ 'buildStyleguide' ]);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "url": "https://github.com/xwp/pwa-template/issues"
   },
   "watch": {
-    "sw-inject-manifest": [ "assets/src/js/sw.js", "workbox-cli-config.js" ]
+    "sw-inject-manifest": [
+      "assets/src/js/sw.js",
+      "workbox-cli-config.js"
+    ]
   },
   "scripts": {
     "dev": "cross-env NODE_ENV=development gulp --gulpfile $(npm root)/undercurrent/src/index.js --cwd $(npm prefix) --workflow theme",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "last 2 iOS versions",
     "last 1 Android version",
     "last 1 ChromeAndroid version",
-    "ie 11",
-    "> 3%"
+    "> 4%"
   ],
   "stylelint": {
     "extends": "stylelint-config-xwp/scss",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "scss-query": "^1.0.1",
     "workbox-cli": "^2.1.0",
     "gulp": "~3.9.0",
-    "sc5-styleguide": "^2.0.4"
+    "sc5-styleguide": "github:SC5/sc5-styleguide"
   },
   "dependencies": {
     "fontfaceobserver": "^2.0.13",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "scss-query": "^1.0.1",
     "workbox-cli": "^2.1.0",
     "gulp": "~3.9.0",
-    "sc5-styleguide": "github:SC5/sc5-styleguide"
+    "sc5-styleguide": "~1.8.1"
   },
   "dependencies": {
     "fontfaceobserver": "^2.0.13",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   },
   "scripts": {
     "dev": "cross-env NODE_ENV=development gulp --gulpfile $(npm root)/undercurrent/src/index.js --cwd $(npm prefix) --workflow theme",
-    "build": "cross-env NODE_ENV=production gulp --gulpfile $(npm root)/undercurrent/src/index.js --cwd $(npm prefix) --workflow theme && workbox inject:manifest",
-    "icons": "gulp --gulpfile ./node_modules/fe-dev-lib/dist/gulpfile.js --cwd ./ --workflow=icons",
+    "build": "cross-env NODE_ENV=production gulp --gulpfile $(npm root)/undercurrent/src/index.js --cwd $(npm prefix) --workflow theme && workbox inject:manifest && cross-env NODE_ENV=production npm run styleguide",
+    "icons": "gulp --gulpfile ./assets/tasks/icons.js --cwd ./",
+    "styleguide": "gulp --gulpfile ./assets/tasks/styleguide.js --cwd ./",
     "sw": "npm-watch",
     "sw-inject-manifest": "workbox inject:manifest",
     "server": "node server.js"
@@ -29,13 +30,6 @@
     "theme": {
       "cwd": "assets",
       "schema": "./assets/schemas/theme.json"
-    },
-    "icons": {
-      "tasks": {
-        "generate-icons-wrapper": {
-          "taskSrc": "./assets/tasks/icons.js"
-        }
-      }
     }
   },
   "browserslist": [
@@ -77,11 +71,13 @@
   },
   "devDependencies": {
     "express": "^4.16.2",
-    "undercurrent": "^0.1.0",
+    "undercurrent": "^0.1.3",
     "gulp-real-favicon": "^0.2.2",
     "npm-watch": "^0.3.0",
     "scss-query": "^1.0.1",
-    "workbox-cli": "^2.1.0"
+    "workbox-cli": "^2.1.0",
+    "gulp": "~3.9.0",
+    "sc5-styleguide": "^2.0.4"
   },
   "dependencies": {
     "fontfaceobserver": "^2.0.13",


### PR DESCRIPTION
Although I originally aimed at adding support for this inside our build tool, due to the incompatibilities with Gulp 4, I had to run it as it's own standalone task.
I didn't go with making all of these options exposed as JSON due to the same thing. 

I've also made the icons a standalone task as there are simply too many options inside it to be worth injecting into undercurrent with an abstraction layer on top.

An issue I've encountered is the unstyled footer in the SC5 I couldn't put my finger on just yet.

To test:
`npm install`
`npm run build`
`npm run server`

Then you'll be able to access it via:
http://localhost:8081/assets/styleguide/ 

Running just
`npm run styleguide`
will turn on the Sc5-styleguides watchmode.

For reference this is how the designer tools show appear correctly, as an overlay:
http://cloud.urldocs.com/1q1H363g1A1q
I generated them using https://github.com/SC5/sc5-styleguide-tutorial just to exclude a bug in SC5.