### PR TITLE
abbr, acronym styles congruent with default browsers styles

### DIFF
--- a/assets/src/css/base/_global.scss
+++ b/assets/src/css/base/_global.scss
@@ -134,7 +134,7 @@ i {
 
 abbr,
 acronym {
-	border-bottom: 1px dotted #666;
+	text-decoration: underline dotted;
 	cursor: help;
 }
 
@@ -278,5 +278,3 @@ tr {
 .hidden {
 	display: none !important;
 }
-
-


### PR DESCRIPTION
```
abbr,
acronym {
	border-bottom: 1px dotted #666;
	cursor: help;
}
```
these were inconsistent with default browser styles, we don't want both border and underline 
https://jsfiddle.net/kps4hygf/3/