### PR TITLE
These can be annoying, the global file should reset styles not set them

### DIFF
--- a/assets/src/css/base/_global.scss
+++ b/assets/src/css/base/_global.scss
@@ -245,15 +245,14 @@ iframe {
  */
 table {
 	border: none;
-	border-top: 1px solid #ccc;
 	border-collapse: collapse;
+	table-layout: fixed;
 	margin: 0 0 20px;
 	width: 100%;
 }
 
 thead th {
-	border-bottom: 2px solid #ccc;
-	padding-bottom: 10px;
+	border: none;
 }
 
 th {
@@ -268,7 +267,7 @@ td {
 }
 
 tr {
-	border-bottom: 1px solid #ccc;
+	border: none;
 }
 
 /*
@@ -278,5 +277,3 @@ tr {
 .hidden {
 	display: none !important;
 }
-
-


### PR DESCRIPTION
-  Remove obsolete styles, the global file should reset styles not set them

- `table-layout: fixed;` is a better performing, more aesthetic option than `table-layout: auto;`

further reading:  
https://css-tricks.com/almanac/properties/t/table-layout/  
https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout